### PR TITLE
Add move preview and confirmation features

### DIFF
--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -26,6 +26,11 @@ public class Cell : MonoBehaviour
         // Старая подсветка (можно оставить)
         spriteRenderer.color = highlightColor;
 
+        if (UnitManager.Instance.HasSelectedUnit() && UnitManager.Instance.CanMoveToCell(this))
+        {
+            UnitManager.Instance.PreviewPath(this);
+        }
+
         // НОВОЕ: если на клетке есть юнит — показать ауру командира
         if (occupyingUnit != null)
         {
@@ -47,6 +52,7 @@ public class Cell : MonoBehaviour
 
         // НОВОЕ: сбросить подсветку ауры всегда!
         UnitManager.Instance.ClearAuraHighlights();
+        UnitManager.Instance.HideMovePreview();
     }
 
     void OnMouseDown()
@@ -61,7 +67,7 @@ public class Cell : MonoBehaviour
         {
             if (UnitManager.Instance.CanMoveToCell(this))
             {
-                UnitManager.Instance.MoveSelectedUnit(transform.position);
+                UnitManager.Instance.RequestMoveConfirmation(this);
                 return;
             }
             else if (UnitManager.Instance.IsAttackHighlightedCell(this))
@@ -116,6 +122,12 @@ public class Cell : MonoBehaviour
         {
             return unit != null && unit.unitData.movementType == MovementType.Flyer;
         }
+
+        if (terrainType == TerrainType.Mountain)
+        {
+            return unit != null && unit.unitData.movementType == MovementType.Flyer;
+        }
+
         return true;
     }
 

--- a/Assets/Scripts/MoveConfirmPanel.cs
+++ b/Assets/Scripts/MoveConfirmPanel.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class MoveConfirmPanel : MonoBehaviour
+{
+    public static MoveConfirmPanel Instance;
+
+    public GameObject panel;
+    public Button confirmButton;
+    public Button cancelButton;
+
+    private Cell targetCell;
+
+    private void Awake()
+    {
+        Instance = this;
+        if (panel != null)
+            panel.SetActive(false);
+        if (confirmButton != null)
+            confirmButton.onClick.AddListener(OnConfirm);
+        if (cancelButton != null)
+            cancelButton.onClick.AddListener(OnCancel);
+    }
+
+    public void Show(Cell cell)
+    {
+        targetCell = cell;
+        if (panel == null) return;
+        panel.SetActive(true);
+        panel.transform.position = Camera.main.WorldToScreenPoint(cell.transform.position);
+    }
+
+    public void Hide()
+    {
+        if (panel != null)
+            panel.SetActive(false);
+        targetCell = null;
+    }
+
+    void OnConfirm()
+    {
+        if (targetCell != null)
+            UnitManager.Instance.ConfirmMove(targetCell);
+        Hide();
+    }
+
+    void OnCancel()
+    {
+        UnitManager.Instance.CancelMove();
+        Hide();
+    }
+}


### PR DESCRIPTION
## Summary
- preview movement path with a LineRenderer and ghost sprite
- add confirmation UI for movement
- restrict mountain tiles to flyers only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fba3b0b14832c914bca74b1f76a7f