### PR TITLE
Fix commander death handling and enemy list enumeration

### DIFF
--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -20,7 +20,9 @@ public class EnemyManager : MonoBehaviour
     {
         UnitManager.Instance.ApplyWaitHealing();
 
-        foreach (var enemy in UnitManager.Instance.AllUnits)
+        // Создаем копию списка, так как во время хода юниты могут погибать
+        var enemiesSnapshot = new List<Unit>(UnitManager.Instance.AllUnits);
+        foreach (var enemy in enemiesSnapshot)
         {
             // Игрок управляет лишь своей фракцией
             if (enemy.faction == Unit.Faction.Player)

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -109,6 +109,21 @@ public class Unit : MonoBehaviour
 
     public void Die()
     {
+        // Сразу удаляем из менеджера юнитов, чтобы безопасно изменить коллекцию
+        if (UnitManager.Instance != null)
+            UnitManager.Instance.UnregisterUnit(this);
+
+        // Если этот юнит — командир, его солдаты также погибают
+        if (isCommander && squad != null)
+        {
+            var soldiers = new List<Unit>(squad);
+            foreach (var s in soldiers)
+            {
+                if (s != null)
+                    s.Die();
+            }
+        }
+
         // Clear the cell this unit occupies
         var cell = UnitManager.Instance.GetCellOfUnit(this);
         if (cell != null && cell.occupyingUnit == this)


### PR DESCRIPTION
## Summary
- prevent collection modification errors during enemy turns by iterating over a snapshot
- automatically kill a commander's squad when the commander dies
- unregister units immediately in `Die` for safe collection updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fdb031154832c83d4178fcd4a5dba