### PR TITLE
Add health bars for units

### DIFF
--- a/Assets/Scripts/HealthBar.cs
+++ b/Assets/Scripts/HealthBar.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public class HealthBar : MonoBehaviour
+{
+    private Unit targetUnit;
+    private SpriteRenderer spriteRenderer;
+    private Vector3 fullScale;
+
+    public void Initialize(Unit unit, Sprite sprite, Color color, Vector3 scale)
+    {
+        targetUnit = unit;
+        spriteRenderer = gameObject.AddComponent<SpriteRenderer>();
+        spriteRenderer.sprite = sprite;
+        spriteRenderer.color = color;
+        spriteRenderer.sortingOrder = 2;
+        fullScale = scale;
+        transform.localScale = fullScale;
+        UpdateBar();
+    }
+
+    public void UpdateBar()
+    {
+        if (targetUnit == null || spriteRenderer == null) return;
+        float percent = Mathf.Clamp01((float)targetUnit.currentHP / targetUnit.unitData.maxHP);
+        transform.localScale = new Vector3(fullScale.x * percent, fullScale.y, fullScale.z);
+    }
+}

--- a/Assets/Scripts/HealthBar.cs.meta
+++ b/Assets/Scripts/HealthBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d03af23-2223-4939-b90b-54f4098415c4

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -39,6 +39,9 @@ public class Unit : MonoBehaviour
     public int currentHP;
     public Faction faction;
 
+    [HideInInspector]
+    public HealthBar healthBar;
+
     public bool isSelected = false;
     private SpriteRenderer spriteRenderer;
     private Color originalColor;
@@ -62,6 +65,8 @@ public class Unit : MonoBehaviour
 
         if (UnitManager.Instance != null)
             UnitManager.Instance.RegisterUnit(this);
+
+        UpdateHealthBar();
     }
 
     void OnDestroy()
@@ -97,10 +102,17 @@ public class Unit : MonoBehaviour
         transform.position = targetPosition;
     }
 
+    public void UpdateHealthBar()
+    {
+        if (healthBar != null)
+            healthBar.UpdateBar();
+    }
+
     public void TakeDamage(int amount)
     {
         Debug.Log($"{name} получил урон: {amount}, HP было: {currentHP}");
         currentHP -= amount;
+        UpdateHealthBar();
         if (currentHP <= 0)
         {
             Die();
@@ -112,6 +124,9 @@ public class Unit : MonoBehaviour
         // Сразу удаляем из менеджера юнитов, чтобы безопасно изменить коллекцию
         if (UnitManager.Instance != null)
             UnitManager.Instance.UnregisterUnit(this);
+
+        if (healthBar != null)
+            Destroy(healthBar.gameObject);
 
         // Если этот юнит — командир, его солдаты также погибают
         if (isCommander && squad != null)

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -19,6 +19,10 @@ public class UnitManager : MonoBehaviour
     public GameObject[] evilNeutralCommanderPrefabs;
     public GameObject[] evilNeutralSoldierPrefabs;
 
+    public Sprite healthBarSprite;
+    public Vector3 healthBarOffset = new Vector3(0f, -0.4f, 0f);
+    public Vector3 healthBarScale = new Vector3(0.8f, 0.1f, 1f);
+
 
     public GridManager gridManager;
     private Unit selectedUnit;
@@ -188,6 +192,16 @@ public class UnitManager : MonoBehaviour
         Unit unit = unitGO.GetComponent<Unit>();
         unit.faction = faction;
 
+        if (healthBarSprite != null)
+        {
+            GameObject barGO = new GameObject("HealthBar");
+            barGO.transform.SetParent(unitGO.transform);
+            barGO.transform.localPosition = healthBarOffset;
+            var hb = barGO.AddComponent<HealthBar>();
+            hb.Initialize(unit, healthBarSprite, GetFactionColor(faction), healthBarScale);
+            unit.healthBar = hb;
+        }
+
         // Назначаем на клетку
         var cell = GetCellOfUnit(unit);
         if (cell != null)
@@ -196,6 +210,21 @@ public class UnitManager : MonoBehaviour
         // Регистрация юнита (если вдруг что-то не сработает в Start юнита)
         RegisterUnit(unit);
         return unit;
+    }
+
+    private Color GetFactionColor(Faction faction)
+    {
+        switch (faction)
+        {
+            case Faction.Player:
+                return Color.green;
+            case Faction.Enemy:
+                return Color.red;
+            case Faction.PlayerAlly:
+                return Color.blue;
+            default:
+                return Color.white;
+        }
     }
 
     // ---- НОВОЕ: Регистрация/удаление ----
@@ -450,6 +479,7 @@ public class UnitManager : MonoBehaviour
                 unit.currentHP = Mathf.Min(unit.currentHP + 3, unit.unitData.maxHP);
                 // Можно добавить анимацию/эффект
                 Debug.Log($"[HEAL] {unit.unitData.unitName} (командир) восстановил 3 HP за ожидание!");
+                unit.UpdateHealthBar();
             }
             // Солдат: если рядом с живым командиром — хил
             else if (!unit.isCommander && unit.commander != null && unit.commander.currentHP > 0)
@@ -462,6 +492,7 @@ public class UnitManager : MonoBehaviour
                 {
                     unit.currentHP = Mathf.Min(unit.currentHP + 3, unit.unitData.maxHP);
                     Debug.Log($"[HEAL] {unit.unitData.unitName} (рядом с командиром) восстановил 3 HP!");
+                    unit.UpdateHealthBar();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `HealthBar` component for displaying per-unit HP bars
- create bar when spawning units and color it by faction
- update bar on damage, healing and death

## Testing
- `ls -R | grep -i test | head`

------
https://chatgpt.com/codex/tasks/task_e_683ff736c1b4832c8faa71d0c892d6c8