### PR TITLE
Fix health bar layer

### DIFF
--- a/Assets/Scripts/HealthBar.cs
+++ b/Assets/Scripts/HealthBar.cs
@@ -12,7 +12,8 @@ public class HealthBar : MonoBehaviour
         spriteRenderer = gameObject.AddComponent<SpriteRenderer>();
         spriteRenderer.sprite = sprite;
         spriteRenderer.color = color;
-        spriteRenderer.sortingOrder = 2;
+        spriteRenderer.sortingLayerID = unit.GetComponent<SpriteRenderer>().sortingLayerID;
+        spriteRenderer.sortingOrder = unit.GetComponent<SpriteRenderer>().sortingOrder + 1;
         fullScale = scale;
         transform.localScale = fullScale;
         UpdateBar();


### PR DESCRIPTION
## Summary
- ensure health bar uses the unit's sorting layer so it's drawn above units

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68400616ee1c832ca69658b596b517c3