### PR TITLE
Fix wait healing conditions

### DIFF
--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -18,8 +18,19 @@ public class EnemyManager : MonoBehaviour
 
     IEnumerator EnemyTurnRoutine(System.Action onEnemiesFinished)
     {
-        // Лечим юниты, которые бездействовали в прошлый ход
-        UnitManager.Instance.ApplyWaitHealing();
+        // Лечим вражеские и нейтральные юниты, которые бездействовали в прошлый ход
+        UnitManager.Instance.ApplyWaitHealing(
+            Unit.Faction.Enemy,
+            Unit.Faction.EnemyAlly,
+            Unit.Faction.Neutral,
+            Unit.Faction.EvilNeutral);
+
+        // Сбрасываем флаги действий у этих юнитов перед их ходом
+        UnitManager.Instance.ResetUnitsForNextTurn(
+            Unit.Faction.Enemy,
+            Unit.Faction.EnemyAlly,
+            Unit.Faction.Neutral,
+            Unit.Faction.EvilNeutral);
 
         // Создаем копию списка, так как во время хода юниты могут погибать
         var enemiesSnapshot = new List<Unit>(UnitManager.Instance.AllUnits);

--- a/Assets/Scripts/PathfindingManager.cs
+++ b/Assets/Scripts/PathfindingManager.cs
@@ -77,11 +77,11 @@ public class PathfindingManager : MonoBehaviour
     List<Cell> GetNeighbors(Cell cell, Unit unit)
     {
         List<Cell> neighbors = new List<Cell>();
+        // Используем только крестообразные смещения, чтобы
+        // движение было по "манхэттенской" сетке
         Vector2Int[] deltas = {
             new Vector2Int(0,1), new Vector2Int(1,0),
-            new Vector2Int(0,-1), new Vector2Int(-1,0),
-            new Vector2Int(1,1), new Vector2Int(-1,1),
-            new Vector2Int(1,-1), new Vector2Int(-1,-1)
+            new Vector2Int(0,-1), new Vector2Int(-1,0)
         };
         Vector2Int pos = GridManager.Instance.WorldToGrid(cell.transform.position);
         foreach (var delta in deltas)

--- a/Assets/Scripts/TurnManager.cs
+++ b/Assets/Scripts/TurnManager.cs
@@ -33,17 +33,11 @@ public class TurnManager : MonoBehaviour
 
     public void StartPlayerTurn()
     {
-        // Сначала лечим все юниты, которые бездействовали в прошлый ход
-        UnitManager.Instance.ApplyWaitHealing();
+        // Сначала лечим юниты игрока, если они ждали прошлый ход
+        UnitManager.Instance.ApplyWaitHealing(Unit.Faction.Player, Unit.Faction.PlayerAlly);
 
-        // Затем обнуляем флаги действий перед новым ходом
-        foreach (var unit in UnitManager.Instance.AllUnits)
-        {
-            unit.hasActed = false;
-            unit.hasMoved = false;
-            unit.hasAttacked = false;
-            unit.SetSelected(false);
-        }
+        // Затем обнуляем флаги действий только у юнитов игрока
+        UnitManager.Instance.ResetUnitsForNextTurn(Unit.Faction.Player, Unit.Faction.PlayerAlly);
 
         currentTurn = Turn.Player;
         Debug.Log("Снова ход игрока!");

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -507,6 +507,26 @@ public class UnitManager : MonoBehaviour
             }
         }
     }
+
+    public void ResetUnitsForNextTurn(params Unit.Faction[] factions)
+    {
+        HashSet<Unit.Faction> allowed;
+        if (factions != null && factions.Length > 0)
+            allowed = new HashSet<Unit.Faction>(factions);
+        else
+            allowed = null; // null означает все фракции
+
+        foreach (var unit in AllUnits)
+        {
+            if (allowed != null && !allowed.Contains(unit.faction))
+                continue;
+
+            unit.hasActed = false;
+            unit.hasMoved = false;
+            unit.hasAttacked = false;
+            unit.SetSelected(false);
+        }
+    }
     private List<Cell> auraHighlightedCells = new List<Cell>();
 
     public void HighlightCommanderAura(Unit commander)


### PR DESCRIPTION
## Summary
- restrict neighbors to cardinal directions for pathfinding
- add `ResetUnitsForNextTurn` helper
- heal and reset units only for the active faction

## Testing
- `find / -name UnityEngine.dll 2>/dev/null | head`


------
https://chatgpt.com/codex/tasks/task_e_684068c9820c832cbacd7bcc8b2ab24d