### PR TITLE
Fix enemy destroy nullref

### DIFF
--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -42,6 +42,10 @@ public class EnemyManager : MonoBehaviour
 
             yield return new WaitForSeconds(0.5f);
 
+            // Юнит мог быть уничтожен, пока мы ждали
+            if (enemy == null)
+                continue;
+
             // Проверяем наличие EnemyAI!
             var ai = enemy.GetComponent<EnemyAI>();
             if (ai != null)


### PR DESCRIPTION
## Summary
- prevent `MissingReferenceException` in `EnemyTurnRoutine` by rechecking enemy reference after wait delay

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684072c8c42c832cba1a961cb140bca0