### PR TITLE
Implement basic dungeon progression system

### DIFF
--- a/Assets/Scripts/DungeonProgressionManager.cs
+++ b/Assets/Scripts/DungeonProgressionManager.cs
@@ -12,11 +12,12 @@ public class DungeonProgressionManager : MonoBehaviour
         public int width;
         public int height;
         public Biome biome;
+        public bool isBoss;
     }
 
-    public int baseWidth = 10;
-    public int baseHeight = 10;
-    public int difficultyStep = 2;
+    public int baseWidth = 28;
+    public int baseHeight = 28;
+    public int sizeVariation = 4;
     public Biome[] possibleBiomes;
 
     private List<LevelInfo> levels = new List<LevelInfo>();
@@ -25,6 +26,11 @@ public class DungeonProgressionManager : MonoBehaviour
     private void Awake()
     {
         Instance = this;
+    }
+
+    void Start()
+    {
+        StartExpedition();
     }
 
     public void StartExpedition()
@@ -47,14 +53,37 @@ public class DungeonProgressionManager : MonoBehaviour
         }
         var info = levels[level - 1];
         GridManager.Instance.Initialize(info.width, info.height, info.seed, info.biome);
+
+        // choose entry/exit positions on opposite sides
+        bool horizontal = Random.value > 0.5f;
+        Vector2Int entry;
+        Vector2Int exit;
+        if (horizontal)
+        {
+            int yEntry = Random.Range(1, info.height - 2);
+            int yExit = Random.Range(1, info.height - 2);
+            entry = new Vector2Int(1, yEntry);
+            exit = new Vector2Int(info.width - 2, yExit);
+        }
+        else
+        {
+            int xEntry = Random.Range(1, info.width - 2);
+            int xExit = Random.Range(1, info.width - 2);
+            entry = new Vector2Int(xEntry, 1);
+            exit = new Vector2Int(xExit, info.height - 2);
+        }
+        GridManager.Instance.PlaceEntryExit(entry, exit);
     }
 
     LevelInfo GenerateLevelInfo(int levelIndex)
     {
         var info = new LevelInfo();
         info.seed = UnityEngine.Random.Range(int.MinValue, int.MaxValue);
-        info.width = baseWidth + difficultyStep * (levelIndex - 1);
-        info.height = baseHeight + difficultyStep * (levelIndex - 1);
+        int variation = Random.Range(-sizeVariation, sizeVariation + 1);
+        bool boss = levelIndex % 10 == 0;
+        info.isBoss = boss;
+        info.width = baseWidth + (boss ? sizeVariation * 2 : variation);
+        info.height = baseHeight + (boss ? sizeVariation * 2 : variation);
         if (possibleBiomes != null && possibleBiomes.Length > 0)
         {
             int idx = UnityEngine.Random.Range(0, possibleBiomes.Length);

--- a/Assets/Scripts/TurnManager.cs
+++ b/Assets/Scripts/TurnManager.cs
@@ -78,6 +78,7 @@ public class TurnManager : MonoBehaviour
         else if (!enemyAlive)
         {
             Debug.Log("Победа!");
+            GridManager.Instance.UnlockExit();
         }
     }
 }

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -346,6 +346,12 @@ public class UnitManager : MonoBehaviour
         if (finalCell != null)
             finalCell.occupyingUnit = unit;
 
+        if (finalCell != null && GridManager.Instance.IsExitCell(finalCell) && GridManager.Instance.ExitUnlocked)
+        {
+            DungeonProgressionManager.Instance.NextLevel();
+            yield break;
+        }
+
         unit.hasMoved = true;
         unit.SetSelected(true);
 


### PR DESCRIPTION
## Summary
- simplify `GridManager` generation
- add entry/exit points and unlocking logic
- vary level sizes with `DungeonProgressionManager` and auto-start expedition
- unlock exit when enemies defeated
- transition to next level when reaching exit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68415868754c832cbf4ca256456f877c