### PR TITLE
Simplify initial spawn and add faction data assets

### DIFF
--- a/Assets/Scripts/FactionData.cs
+++ b/Assets/Scripts/FactionData.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "FactionData", menuName = "SRPG/Faction Data")]
+public class FactionData : ScriptableObject
+{
+    public Unit.Faction faction;
+    public Color color = Color.white;
+    public Sprite icon;
+    public Sprite flag;
+    [TextArea]
+    public string description;
+}

--- a/Assets/Scripts/FactionManager.cs
+++ b/Assets/Scripts/FactionManager.cs
@@ -6,6 +6,9 @@ public class FactionManager : MonoBehaviour
     public static FactionManager Instance;
     public static Unit.Faction PlayerFaction = Unit.Faction.AuroraEmpire;
 
+    public FactionData[] factionDatas;
+    private Dictionary<Unit.Faction, FactionData> factionDataDict = new Dictionary<Unit.Faction, FactionData>();
+
     public enum RelationType { Ally, Enemy, Neutral }
 
     // Таблица отношений: кто как относится к кому
@@ -15,7 +18,27 @@ public class FactionManager : MonoBehaviour
     private void Awake()
     {
         Instance = this;
+        BuildFactionDictionary();
         InitializeRelations();
+    }
+
+    void BuildFactionDictionary()
+    {
+        factionDataDict.Clear();
+        if (factionDatas != null)
+        {
+            foreach (var data in factionDatas)
+            {
+                if (data != null)
+                    factionDataDict[data.faction] = data;
+            }
+        }
+    }
+
+    public FactionData GetFactionData(Unit.Faction faction)
+    {
+        factionDataDict.TryGetValue(faction, out var data);
+        return data;
     }
 
     private void InitializeRelations()

--- a/Assets/Scripts/UnitData.cs
+++ b/Assets/Scripts/UnitData.cs
@@ -22,6 +22,16 @@ public class UnitData : ScriptableObject
     public int commanderRangeBonus;
     [TextArea]
     public string description;
+
+    [System.Serializable]
+    public class FactionVariant
+    {
+        public Unit.Faction faction;
+        public string unitName;
+        public Sprite sprite;
+    }
+
+    public FactionVariant[] factionVariants;
 }
 public enum UnitClass
 {

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -64,24 +64,12 @@ public class UnitManager : MonoBehaviour
     void Start()
     {
         AllUnits.Clear();
-        int w = gridManager.width;
-        int h = gridManager.height;
 
-        // КООРДИНАТЫ для командиров
-        Vector2Int playerPos = new Vector2Int(w / 2, h / 2);
-        Vector2Int faction2Pos = new Vector2Int(w - 2, h - 2);
-        Vector2Int faction3Pos = new Vector2Int(w - 2, h / 2);
-        Vector2Int neutralPos = new Vector2Int(1, 1);
-        Vector2Int evilNeutralPos = new Vector2Int(w - 2, 1);
+        Vector2Int playerPos = GridManager.Instance.entryPoint;
+        Vector2Int evilPos = GridManager.Instance.exitPoint;
 
-        // СПАВН: фракции
-        SpawnSquad(playerCommanderPrefabs, playerSoldierPrefabs, playerPos, 2, Unit.Faction.AuroraEmpire);
-        SpawnSquad(enemyCommanderPrefabs, enemySoldierPrefabs, faction2Pos, 2, Unit.Faction.MoonArchonDominion);
-        SpawnSquad(allyCommanderPrefabs, allySoldierPrefabs, faction3Pos, 2, Unit.Faction.GoldenHand);
-        // нейтралы
-        SpawnSquad(neutralCommanderPrefabs, neutralSoldierPrefabs, neutralPos, 2, Unit.Faction.Neutral);
-        // Злые Нейтралы
-        SpawnSquad(evilNeutralCommanderPrefabs, evilNeutralSoldierPrefabs, evilNeutralPos, 2, Unit.Faction.EvilNeutral);
+        SpawnSquad(playerCommanderPrefabs, playerSoldierPrefabs, playerPos, 1, Unit.Faction.AuroraEmpire);
+        SpawnSquad(evilNeutralCommanderPrefabs, evilNeutralSoldierPrefabs, evilPos, 1, Unit.Faction.EvilNeutral);
     }
 
     // Спавнит командира и n солдат вокруг него по ближайшим свободным клеткам
@@ -210,6 +198,10 @@ public class UnitManager : MonoBehaviour
 
     private Color GetFactionColor(Faction faction)
     {
+        var data = FactionManager.Instance?.GetFactionData(faction);
+        if (data != null)
+            return data.color;
+
         switch (faction)
         {
             case Faction.AuroraEmpire:


### PR DESCRIPTION
## Summary
- spawn only player and evil neutral squads on map start
- support faction colors and metadata via new `FactionData` scriptable object
- allow `UnitData` to define per–faction name and sprite variants

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6841680a5d5c832cba6c6780bd82e62f