### PR TITLE
Add entry/exit and road generation logic

### DIFF
--- a/Assets/Scripts/DungeonProgressionManager.cs
+++ b/Assets/Scripts/DungeonProgressionManager.cs
@@ -60,19 +60,19 @@ public class DungeonProgressionManager : MonoBehaviour
         Vector2Int exit;
         if (horizontal)
         {
-            int yEntry = Random.Range(1, info.height - 2);
-            int yExit = Random.Range(1, info.height - 2);
-            entry = new Vector2Int(1, yEntry);
-            exit = new Vector2Int(info.width - 2, yExit);
+            int yEntry = Random.Range(0, info.height);
+            int yExit = Random.Range(0, info.height);
+            entry = new Vector2Int(0, yEntry);
+            exit = new Vector2Int(info.width - 1, yExit);
         }
         else
         {
-            int xEntry = Random.Range(1, info.width - 2);
-            int xExit = Random.Range(1, info.width - 2);
-            entry = new Vector2Int(xEntry, 1);
-            exit = new Vector2Int(xExit, info.height - 2);
+            int xEntry = Random.Range(0, info.width);
+            int xExit = Random.Range(0, info.width);
+            entry = new Vector2Int(xEntry, 0);
+            exit = new Vector2Int(xExit, info.height - 1);
         }
-        GridManager.Instance.PlaceEntryExit(entry, exit);
+        GridManager.Instance.PlaceEntryExit(entry, exit, level == 1);
     }
 
     LevelInfo GenerateLevelInfo(int levelIndex)


### PR DESCRIPTION
## Summary
- update dungeon progression to place entry/exit on outer grid tiles
- first level starts at gate with wall border
- build road between entry and exit using A* and bridges over rivers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423391a76c832cb62a6d0e266eb2a0