### PR TITLE
Add terrain cluster generation and spawn squads

### DIFF
--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -165,4 +165,13 @@ public class Cell : MonoBehaviour
                 return moveCost;
         }
     }
+
+    // Set a base color for the cell and remember it as original
+    public void SetBaseColor(Color color)
+    {
+        if (spriteRenderer == null)
+            spriteRenderer = GetComponent<SpriteRenderer>();
+        spriteRenderer.color = color;
+        originalColor = color;
+    }
 }

--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -21,6 +21,9 @@ public class GridManager : MonoBehaviour
 
     private System.Random rng;
 
+    public Color entryHighlight = new Color(0.8f, 1f, 0.6f);
+    public Color exitHighlight = new Color(1f, 0.6f, 0.6f);
+
     public Vector2Int entryPoint;
     public Vector2Int exitPoint;
     private bool exitUnlocked = false;
@@ -218,6 +221,107 @@ public class GridManager : MonoBehaviour
                 SetCellTerrain(x, y, t);
             }
         }
+
+        GenerateFeatures();
+    }
+
+    void GenerateFeatures()
+    {
+        // Lakes with surrounding cliffs
+        int lakeCount = rng.Next(1, 3);
+        for (int i = 0; i < lakeCount; i++)
+        {
+            var lake = GenerateCluster(TerrainType.Ocean, rng.Next(4, 8), 2);
+            foreach (var p in lake)
+            {
+                Vector2Int[] deltas = { new Vector2Int(0,1), new Vector2Int(1,0), new Vector2Int(0,-1), new Vector2Int(-1,0) };
+                foreach (var d in deltas)
+                {
+                    Vector2Int n = p + d;
+                    if (n.x >= 0 && n.x < width && n.y >= 0 && n.y < height)
+                    {
+                        if (cells[n.x, n.y].terrainType == TerrainType.Grass)
+                            SetCellTerrain(n.x, n.y, TerrainType.Cliff);
+                    }
+                }
+            }
+        }
+
+        // Forest clusters
+        int forestClusters = rng.Next(3, 6);
+        for (int i = 0; i < forestClusters; i++)
+            GenerateCluster(TerrainType.Forest, rng.Next(6, 12), 1);
+
+        // Mountain clusters with hills around
+        int mountainClusters = rng.Next(1, 3);
+        for (int i = 0; i < mountainClusters; i++)
+        {
+            var mts = GenerateCluster(TerrainType.Mountain, rng.Next(3, 6), 2);
+            foreach (var p in mts)
+            {
+                for (int dx = -1; dx <= 1; dx++)
+                {
+                    for (int dy = -1; dy <= 1; dy++)
+                    {
+                        if (dx == 0 && dy == 0) continue;
+                        Vector2Int n = new Vector2Int(p.x + dx, p.y + dy);
+                        if (n.x >= 0 && n.x < width && n.y >= 0 && n.y < height)
+                        {
+                            if (cells[n.x, n.y].terrainType == TerrainType.Grass)
+                                SetCellTerrain(n.x, n.y, TerrainType.Hill);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Rivers
+        int riverCount = rng.Next(1, 3);
+        for (int i = 0; i < riverCount; i++)
+        {
+            Vector2Int start = new Vector2Int(rng.Next(width), rng.Next(2) == 0 ? 0 : height - 1);
+            Vector2Int end = new Vector2Int(rng.Next(width), start.y == 0 ? height - 1 : 0);
+            if (rng.Next(2) == 0)
+            {
+                start = new Vector2Int(0, rng.Next(height));
+                end = new Vector2Int(width - 1, rng.Next(height));
+            }
+            GenerateRiver(start, end);
+        }
+
+        // Fortress with walls, gates and town tiles
+        if (width > 6 && height > 6)
+        {
+            int cx = rng.Next(3, width - 3);
+            int cy = rng.Next(3, height - 3);
+
+            for (int x = cx - 1; x <= cx + 1; x++)
+                for (int y = cy - 1; y <= cy + 1; y++)
+                    SetCellTerrain(x, y, TerrainType.Town);
+
+            for (int x = cx - 2; x <= cx + 2; x++)
+            {
+                for (int y = cy - 2; y <= cy + 2; y++)
+                {
+                    bool border = x == cx - 2 || x == cx + 2 || y == cy - 2 || y == cy + 2;
+                    if (border)
+                        SetCellTerrain(x, y, TerrainType.Wall);
+                }
+            }
+
+            // gates
+            int gates = rng.Next(1, 3);
+            for (int g = 0; g < gates; g++)
+            {
+                int side = rng.Next(4);
+                Vector2Int pos;
+                if (side == 0) pos = new Vector2Int(cx, cy - 2);
+                else if (side == 1) pos = new Vector2Int(cx, cy + 2);
+                else if (side == 2) pos = new Vector2Int(cx - 2, cy);
+                else pos = new Vector2Int(cx + 2, cy);
+                SetCellTerrain(pos.x, pos.y, TerrainType.Gate);
+            }
+        }
     }
 
 
@@ -266,6 +370,8 @@ public class GridManager : MonoBehaviour
 
         SetCellTerrain(exitPoint.x, exitPoint.y, TerrainType.Road);
         SetCellTerrain(entryPoint.x, entryPoint.y, firstLevel ? TerrainType.Gate : TerrainType.Road);
+        cells[entryPoint.x, entryPoint.y].SetBaseColor(entryHighlight);
+        cells[exitPoint.x, exitPoint.y].SetBaseColor(exitHighlight);
 
         if (firstLevel)
             BuildEntryWalls();

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -68,8 +68,8 @@ public class UnitManager : MonoBehaviour
         Vector2Int playerPos = GridManager.Instance.entryPoint;
         Vector2Int evilPos = GridManager.Instance.exitPoint;
 
-        SpawnSquad(playerCommanderPrefabs, playerSoldierPrefabs, playerPos, 1, Unit.Faction.AuroraEmpire);
-        SpawnSquad(evilNeutralCommanderPrefabs, evilNeutralSoldierPrefabs, evilPos, 1, Unit.Faction.EvilNeutral);
+        SpawnSquad(playerCommanderPrefabs, playerSoldierPrefabs, playerPos, 2, Unit.Faction.AuroraEmpire);
+        SpawnSquad(evilNeutralCommanderPrefabs, evilNeutralSoldierPrefabs, evilPos, 2, Unit.Faction.EvilNeutral);
     }
 
     // Спавнит командира и n солдат вокруг него по ближайшим свободным клеткам


### PR DESCRIPTION
## Summary
- add method in `Cell` to allow coloring tiles and use it for entry/exit highlight
- highlight entry/exit cells in `GridManager`
- implement generation of lakes, forests, mountains, rivers and fortresses to make the map less random
- spawn commanders with two soldiers each

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68423e68deb0832cbc42b5727ce43449