### PR TITLE
Fix exit activation without enemies

### DIFF
--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -587,5 +587,5 @@ public class GridManager : MonoBehaviour
         return pos == exitPoint;
     }
 
-    public bool ExitUnlocked => exitUnlocked;
+    public bool IsExitUnlocked => exitUnlocked;
 }

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -70,6 +70,9 @@ public class UnitManager : MonoBehaviour
 
         SpawnSquad(playerCommanderPrefabs, playerSoldierPrefabs, playerPos, 2, Unit.Faction.AuroraEmpire);
         SpawnSquad(evilNeutralCommanderPrefabs, evilNeutralSoldierPrefabs, evilPos, 2, Unit.Faction.EvilNeutral);
+
+        // Проверим, остались ли противники. Если никого нет, открываем выход
+        TurnManager.Instance?.CheckVictory();
     }
 
     // Спавнит командира и n солдат вокруг него по ближайшим свободным клеткам
@@ -333,7 +336,7 @@ public class UnitManager : MonoBehaviour
         if (finalCell != null)
             finalCell.occupyingUnit = unit;
 
-        if (finalCell != null && GridManager.Instance.IsExitCell(finalCell) && GridManager.Instance.ExitUnlocked)
+        if (finalCell != null && GridManager.Instance.IsExitCell(finalCell) && GridManager.Instance.IsExitUnlocked)
         {
             DungeonProgressionManager.Instance.NextLevel();
             yield break;


### PR DESCRIPTION
## Summary
- expose exit unlocked status as `IsExitUnlocked`
- check victory at the start of UnitManager to unlock exit when no foes
- updated move routine to use the new property

## Testing
- `grep -R "Test" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_68432c994508832cb66ca8287dbbeb53