### PR TITLE
Enhance commander aura bonuses

### DIFF
--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -63,6 +63,42 @@ public class Unit : MonoBehaviour
     public int attackRangeBonus = 0;
     public int AttackRangeTotal => AttackRangeBase + attackRangeBonus;
 
+    // ----- Commander aura bonuses -----
+    public int GetAuraAttackBonus()
+    {
+        if (!IsInAura()) return 0;
+        Unit src = isCommander ? this : commander;
+        return src != null ? src.unitData.commanderAttackBonus : 0;
+    }
+
+    public int GetAuraDefenseBonus()
+    {
+        if (!IsInAura()) return 0;
+        Unit src = isCommander ? this : commander;
+        return src != null ? src.unitData.commanderDefenseBonus : 0;
+    }
+
+    public int GetAuraMagicAttackBonus()
+    {
+        if (!IsInAura()) return 0;
+        Unit src = isCommander ? this : commander;
+        return src != null ? src.unitData.commanderMagicAttackBonus : 0;
+    }
+
+    public int GetAuraMagicDefenseBonus()
+    {
+        if (!IsInAura()) return 0;
+        Unit src = isCommander ? this : commander;
+        return src != null ? src.unitData.commanderMagicDefenseBonus : 0;
+    }
+
+    public int GetAuraRangeBonus()
+    {
+        if (!IsInAura()) return 0;
+        Unit src = isCommander ? this : commander;
+        return src != null ? src.unitData.commanderRangeBonus : 0;
+    }
+
     [HideInInspector]
     public HealthBar healthBar;
 
@@ -248,7 +284,11 @@ public class Unit : MonoBehaviour
         myPower += GetAttackBonus();
         theirDef += target.GetDefenseBonus();
 
-        // ======= Бонусы за ауру =======
+        // ======= Бонусы за ауру командира =======
+        myPower += GetAuraAttackBonus();
+        theirDef += target.GetAuraDefenseBonus();
+
+        // Старые плоские бонусы ауры
         if (IsInAura()) myPower += 2;             // если в ауре, атака +2
         if (target.IsInAura()) theirDef += 1;     // если цель в ауре, защита +1
 
@@ -279,6 +319,7 @@ public class Unit : MonoBehaviour
         {
             range += 1; // бонус за высоту
         }
+        range += GetAuraRangeBonus();
         return range;
     }
 

--- a/Assets/Scripts/UnitInfoPanel.cs
+++ b/Assets/Scripts/UnitInfoPanel.cs
@@ -62,6 +62,23 @@ public class UnitInfoPanel : MonoBehaviour
             if (!string.IsNullOrEmpty(commanderStr))
                 stats += $"\nКомандование: {commanderStr}";
         }
+        else if (unit.commander != null)
+        {
+            var cd = unit.commander.unitData;
+            string auraStr = "";
+            if (cd.commanderAttackBonus != 0) auraStr += $"ATK +{cd.commanderAttackBonus} ";
+            if (cd.commanderDefenseBonus != 0) auraStr += $"DEF +{cd.commanderDefenseBonus} ";
+            if (cd.commanderMagicAttackBonus != 0) auraStr += $"M.ATK +{cd.commanderMagicAttackBonus} ";
+            if (cd.commanderMagicDefenseBonus != 0) auraStr += $"M.DEF +{cd.commanderMagicDefenseBonus} ";
+            if (cd.commanderRangeBonus != 0) auraStr += $"RNG +{cd.commanderRangeBonus}";
+            if (!string.IsNullOrEmpty(auraStr))
+            {
+                if (unit.IsInAura())
+                    stats += $"\nВ ауре командира: {auraStr}";
+                else
+                    stats += $"\nКомандир: {unit.commander.unitData.unitName}";
+            }
+        }
         statsText.text = stats;
         descriptionText.text = unit.unitData.description;
     }

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -546,6 +546,10 @@ public class UnitManager : MonoBehaviour
                     unit.UpdateHealthBar();
                 }
             }
+
+            // Поднять мораль за нахождение в ауре командира
+            if (unit.IsInAura())
+                unit.ModifyMorale(1);
         }
     }
 


### PR DESCRIPTION
## Summary
- support aura bonuses from commander UnitData when soldiers are near
- show active commander buffs in the unit info panel
- give units +1 morale each turn while in command range

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68435316ca8c832c8fcdb143e0afa7fa