### PR TITLE
Improve commander morale system

### DIFF
--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -99,6 +99,13 @@ public class Unit : MonoBehaviour
         return src != null ? src.unitData.commanderRangeBonus : 0;
     }
 
+    public int GetAuraMoraleBonus()
+    {
+        if (!IsInAura()) return 0;
+        Unit src = isCommander ? this : commander;
+        return src != null ? src.unitData.commanderMoraleBonus : 0;
+    }
+
     [HideInInspector]
     public HealthBar healthBar;
 
@@ -247,15 +254,19 @@ public class Unit : MonoBehaviour
         if (healthBar != null)
             Destroy(healthBar.gameObject);
 
-        // Если этот юнит — командир, его солдаты также погибают
+        // Если этот юнит — командир, его солдаты теряют связь и мораль
         if (isCommander && squad != null)
         {
             var soldiers = new List<Unit>(squad);
             foreach (var s in soldiers)
             {
                 if (s != null)
-                    s.Die();
+                {
+                    s.ModifyMorale(-30);
+                    s.commander = null;
+                }
             }
+            squad.Clear();
         }
 
         // Clear the cell this unit occupies

--- a/Assets/Scripts/UnitData.cs
+++ b/Assets/Scripts/UnitData.cs
@@ -20,6 +20,7 @@ public class UnitData : ScriptableObject
     public int commanderMagicAttackBonus;
     public int commanderMagicDefenseBonus;
     public int commanderRangeBonus;
+    public int commanderMoraleBonus = 1;
     [TextArea]
     public string description;
 

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -549,7 +549,7 @@ public class UnitManager : MonoBehaviour
 
             // Поднять мораль за нахождение в ауре командира
             if (unit.IsInAura())
-                unit.ModifyMorale(1);
+                unit.ModifyMorale(Mathf.Max(1, unit.GetAuraMoraleBonus()));
         }
     }
 


### PR DESCRIPTION
## Summary
- add `commanderMoraleBonus` stat to `UnitData`
- expose new helper `GetAuraMoraleBonus` in `Unit`
- boost morale from aura based on `commanderMoraleBonus`
- changed commander death so soldiers only lose morale instead of dying

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684357a975d0832cbfef1f3a27d9d923