### PR TITLE
Switch grid to tilemap rendering

### DIFF
--- a/Assets/Scripts/Biome.cs
+++ b/Assets/Scripts/Biome.cs
@@ -1,26 +1,25 @@
 using UnityEngine;
+using UnityEngine.Tilemaps;
 
 [System.Serializable]
-public class TerrainSpriteSet
+public class TerrainTileSet
 {
     public TerrainType terrainType;
-    public Sprite[] sprites;
+    public TileBase[] tiles;
 }
 
 [CreateAssetMenu(menuName = "Terrain/Biome")]
 public class Biome : ScriptableObject
 {
     public string biomeName;
-    public TerrainSpriteSet[] terrainSprites;
+    public TerrainTileSet[] terrainTiles;
 
-    public Sprite GetSprite(TerrainType type)
+    public TileBase GetTile(TerrainType type)
     {
-        foreach (var set in terrainSprites)
+        foreach (var set in terrainTiles)
         {
-            if (set.terrainType == type && set.sprites != null && set.sprites.Length > 0)
-            {
-                return set.sprites[Random.Range(0, set.sprites.Length)];
-            }
+            if (set.terrainType == type && set.tiles != null && set.tiles.Length > 0)
+                return set.tiles[Random.Range(0, set.tiles.Length)];
         }
         return null;
     }

--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -18,7 +18,15 @@ public class Cell : MonoBehaviour
     void Awake()
     {
         spriteRenderer = GetComponent<SpriteRenderer>();
-        originalColor = spriteRenderer.color;
+        if (spriteRenderer.sprite == null)
+        {
+            var tex = new Texture2D(1, 1);
+            tex.SetPixel(0, 0, Color.white);
+            tex.Apply();
+            spriteRenderer.sprite = Sprite.Create(tex, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f), 1f);
+        }
+        originalColor = new Color(1f, 1f, 1f, 0f);
+        spriteRenderer.color = originalColor;
     }
     void OnMouseEnter()
     {
@@ -97,13 +105,13 @@ public class Cell : MonoBehaviour
 
     public void Unhighlight()
     {
-        spriteRenderer.color = Color.white;
+        spriteRenderer.color = originalColor;
         isMoveHighlight = false;
     }
 
     public void HighlightAura(Color color)
     {
-        GetComponent<SpriteRenderer>().color = color;
+        spriteRenderer.color = color;
     }
 
     public void UnhighlightAura()
@@ -111,9 +119,9 @@ public class Cell : MonoBehaviour
         // Если клетка уже подсвечена как зона движения, оставляем cyan,
         // иначе возвращаем исходный цвет
         if (isMoveHighlight)
-            GetComponent<SpriteRenderer>().color = Color.cyan;
+            spriteRenderer.color = Color.cyan;
         else
-            GetComponent<SpriteRenderer>().color = originalColor;
+            spriteRenderer.color = originalColor;
     }
 
     public bool IsPassable(Unit unit)

--- a/Assets/Scripts/StatusBarUI.cs
+++ b/Assets/Scripts/StatusBarUI.cs
@@ -24,7 +24,8 @@ public class StatusBarUI : MonoBehaviour
     public void ShowCellInfo(Cell cell)
     {
         // --- Клетка ---
-        cellIcon.sprite = cell.GetComponent<SpriteRenderer>().sprite;
+        Vector2Int gridPos = GridManager.Instance.WorldToGrid(cell.transform.position);
+        cellIcon.sprite = GridManager.Instance.terrainTilemap.GetSprite((Vector3Int)gridPos);
         cellIcon.enabled = true;
         cellInfoText.text = $"Местность: {cell.terrainType}\n" +
                             $"Сложн. хода: {cell.moveCost}";


### PR DESCRIPTION
## Summary
- convert `Biome` to store tiles instead of sprites
- add tilemap layers to `GridManager` and set tiles during generation
- create 1x1 runtime sprite for `Cell` highlights
- adjust `StatusBarUI` to read tilemap sprites

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435f04423c832c9bd1d753891a6da1