### PR TITLE
Switch grid to tilemap rendering

### DIFF
--- a/Assets/Scripts/Biome.cs
+++ b/Assets/Scripts/Biome.cs
@@ -1,26 +1,25 @@
 using UnityEngine;
+using UnityEngine.Tilemaps;
 
 [System.Serializable]
-public class TerrainSpriteSet
+public class TerrainTileSet
 {
     public TerrainType terrainType;
-    public Sprite[] sprites;
+    public TileBase[] tiles;
 }
 
 [CreateAssetMenu(menuName = "Terrain/Biome")]
 public class Biome : ScriptableObject
 {
     public string biomeName;
-    public TerrainSpriteSet[] terrainSprites;
+    public TerrainTileSet[] terrainTiles;
 
-    public Sprite GetSprite(TerrainType type)
+    public TileBase GetTile(TerrainType type)
     {
-        foreach (var set in terrainSprites)
+        foreach (var set in terrainTiles)
         {
-            if (set.terrainType == type && set.sprites != null && set.sprites.Length > 0)
-            {
-                return set.sprites[Random.Range(0, set.sprites.Length)];
-            }
+            if (set.terrainType == type && set.tiles != null && set.tiles.Length > 0)
+                return set.tiles[Random.Range(0, set.tiles.Length)];
         }
         return null;
     }

--- a/Assets/Scripts/Cell.cs
+++ b/Assets/Scripts/Cell.cs
@@ -18,7 +18,15 @@ public class Cell : MonoBehaviour
     void Awake()
     {
         spriteRenderer = GetComponent<SpriteRenderer>();
-        originalColor = spriteRenderer.color;
+        if (spriteRenderer.sprite == null)
+        {
+            var tex = new Texture2D(1, 1);
+            tex.SetPixel(0, 0, Color.white);
+            tex.Apply();
+            spriteRenderer.sprite = Sprite.Create(tex, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f), 1f);
+        }
+        originalColor = new Color(1f, 1f, 1f, 0f);
+        spriteRenderer.color = originalColor;
     }
     void OnMouseEnter()
     {
@@ -97,13 +105,13 @@ public class Cell : MonoBehaviour
 
     public void Unhighlight()
     {
-        spriteRenderer.color = Color.white;
+        spriteRenderer.color = originalColor;
         isMoveHighlight = false;
     }
 
     public void HighlightAura(Color color)
     {
-        GetComponent<SpriteRenderer>().color = color;
+        spriteRenderer.color = color;
     }
 
     public void UnhighlightAura()
@@ -111,9 +119,9 @@ public class Cell : MonoBehaviour
         // Если клетка уже подсвечена как зона движения, оставляем cyan,
         // иначе возвращаем исходный цвет
         if (isMoveHighlight)
-            GetComponent<SpriteRenderer>().color = Color.cyan;
+            spriteRenderer.color = Color.cyan;
         else
-            GetComponent<SpriteRenderer>().color = originalColor;
+            spriteRenderer.color = originalColor;
     }
 
     public bool IsPassable(Unit unit)

--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Tilemaps;
 using Priority_Queue;
 
 public class GridManager : MonoBehaviour
@@ -9,13 +10,21 @@ public class GridManager : MonoBehaviour
     public int width = 10;
     public int height = 10;
     public float cellSize = 1f;
-    public Sprite[] tileSprites;
     public Biome biome;
-    public Material cellMaterial;
+
+    [Header("Tilemaps")]
+    public Tilemap groundTilemap;
+    public Tilemap terrainTilemap;
+    public Tilemap objectTilemap;
+    public TileBase groundTile;
 
     [Header("Noise Settings")]
-    public bool usePerlinNoise = false;
-    public float noiseScale = 0.1f;
+    public bool usePerlinNoise = true;
+    public float terrainNoiseScale = 0.1f;
+    public float objectNoiseScale = 0.2f;
+
+    [Header("Generation Options")]
+    public bool generateFeatures = false;
 
     // Seed for deterministic generation
     public int seed = 0;
@@ -63,15 +72,13 @@ public class GridManager : MonoBehaviour
     void Start()
     {
     }
-    Sprite GetSpriteForType(TerrainType type)
+    TileBase GetTileForType(TerrainType type)
     {
         if (biome != null)
         {
-            Sprite s = biome.GetSprite(type);
-            if (s != null) return s;
+            TileBase t = biome.GetTile(type);
+            if (t != null) return t;
         }
-        if (tileSprites != null && tileSprites.Length > 0)
-            return tileSprites[rng.Next(tileSprites.Length)];
         return null;
     }
 
@@ -111,12 +118,15 @@ public class GridManager : MonoBehaviour
         Cell cell = cells[x, y];
         cell.terrainType = tType;
         cell.moveCost = GetMoveCostForType(tType);
-        cell.GetComponent<SpriteRenderer>().sprite = GetSpriteForType(tType);
+
+        TileBase tile = GetTileForType(tType);
+        if (tile != null)
+            terrainTilemap.SetTile(new Vector3Int(x, y, 0), tile);
     }
 
     TerrainType ChooseTerrainType(int x, int y)
     {
-        float noise = Mathf.PerlinNoise((x + seed) * noiseScale, (y + seed) * noiseScale);
+        float noise = Mathf.PerlinNoise((x + seed) * terrainNoiseScale, (y + seed) * terrainNoiseScale);
         if (noise < 0.2f) return TerrainType.Ocean;
         if (noise < 0.4f) return TerrainType.Forest;
         if (noise < 0.6f) return TerrainType.Grass;
@@ -126,10 +136,10 @@ public class GridManager : MonoBehaviour
 
     TerrainType ChooseTerrainType()
     {
-        if (biome != null && biome.terrainSprites != null && biome.terrainSprites.Length > 0)
+        if (biome != null && biome.terrainTiles != null && biome.terrainTiles.Length > 0)
         {
             List<TerrainType> allowed = new List<TerrainType>();
-            foreach (var set in biome.terrainSprites)
+            foreach (var set in biome.terrainTiles)
             {
                 switch (set.terrainType)
                 {
@@ -227,6 +237,10 @@ public class GridManager : MonoBehaviour
         float xOffset = -((width - 1) * cellSize) / 2f;
         float yOffset = -((height - 1) * cellSize) / 2f;
 
+        groundTilemap.ClearAllTiles();
+        terrainTilemap.ClearAllTiles();
+        objectTilemap.ClearAllTiles();
+
         cells = new Cell[width, height];
 
         for (int x = 0; x < width; x++)
@@ -238,9 +252,7 @@ public class GridManager : MonoBehaviour
                 cell.transform.parent = transform;
 
                 var spriteRenderer = cell.AddComponent<SpriteRenderer>();
-                spriteRenderer.color = Color.white;
-                if (cellMaterial != null)
-                    spriteRenderer.material = cellMaterial;
+                spriteRenderer.color = new Color(1f,1f,1f,0f);
 
                 cell.transform.localScale = Vector3.one;
 
@@ -249,16 +261,34 @@ public class GridManager : MonoBehaviour
                 Cell cellScript = cell.AddComponent<Cell>();
                 cells[x, y] = cellScript;
 
+                if (groundTile != null)
+                    groundTilemap.SetTile(new Vector3Int(x, y, 0), groundTile);
+
                 TerrainType t;
                 if (usePerlinNoise)
                     t = ChooseTerrainType(x, y);
                 else
                     t = ChooseTerrainType();
                 SetCellTerrain(x, y, t);
+
+                if (usePerlinNoise && objectTilemap != null)
+                {
+                    TileBase objTile = GetTileForType(TerrainType.Forest);
+                    if (objTile != null)
+                    {
+                        float objNoise = Mathf.PerlinNoise((x + seed + 1000) * objectNoiseScale, (y + seed + 1000) * objectNoiseScale);
+                        if (objNoise > 0.7f && t == TerrainType.Grass)
+                            objectTilemap.SetTile(new Vector3Int(x, y, 0), objTile);
+                    }
+                }
             }
         }
 
-        GenerateFeatures();
+        if (generateFeatures)
+            GenerateFeatures();
+
+        terrainTilemap.RefreshAllTiles();
+        objectTilemap.RefreshAllTiles();
     }
 
     void GenerateFeatures()

--- a/Assets/Scripts/StatusBarUI.cs
+++ b/Assets/Scripts/StatusBarUI.cs
@@ -24,7 +24,8 @@ public class StatusBarUI : MonoBehaviour
     public void ShowCellInfo(Cell cell)
     {
         // --- Клетка ---
-        cellIcon.sprite = cell.GetComponent<SpriteRenderer>().sprite;
+        Vector2Int gridPos = GridManager.Instance.WorldToGrid(cell.transform.position);
+        cellIcon.sprite = GridManager.Instance.terrainTilemap.GetSprite((Vector3Int)gridPos);
         cellIcon.enabled = true;
         cellInfoText.text = $"Местность: {cell.terrainType}\n" +
                             $"Сложн. хода: {cell.moveCost}";


### PR DESCRIPTION
## Summary
- convert `Biome` to store tiles instead of sprites
- add tilemap references and noise settings to `GridManager` and set tiles during generation
- create 1x1 runtime sprite for `Cell` highlights
- adjust `StatusBarUI` to read tilemap sprites
- make map feature generation optional

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435f04423c832c9bd1d753891a6da1