### PR TITLE
Fix unit spawn timing

### DIFF
--- a/Assets/Scripts/DungeonProgressionManager.cs
+++ b/Assets/Scripts/DungeonProgressionManager.cs
@@ -73,6 +73,9 @@ public class DungeonProgressionManager : MonoBehaviour
             exit = new Vector2Int(xExit, info.height - 1);
         }
         GridManager.Instance.PlaceEntryExit(entry, exit, level == 1);
+
+        // После размещения входа и выхода генерируем начальные отряды
+        UnitManager.Instance?.SpawnInitialUnits();
     }
 
     LevelInfo GenerateLevelInfo(int levelIndex)

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -61,6 +61,12 @@ public class UnitManager : MonoBehaviour
 
     void Start()
     {
+        // Отложим спавн юнитов до момента, когда грид будет полностью инициализирован
+    }
+
+    // Вызывается после генерации уровня для размещения начальных отрядов
+    public void SpawnInitialUnits()
+    {
         AllUnits.Clear();
 
         Vector2Int playerPos = GridManager.Instance.entryPoint;


### PR DESCRIPTION
## Summary
- ensure units spawn after GridManager finishes generating
- add `SpawnInitialUnits` method to `UnitManager`
- call it from `DungeonProgressionManager` once entry and exit are placed

## Testing
- `ls > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_684a6ad7dca8832c8a73d41386bead51