### PR TITLE
Fix UnitInfoPanel null check and hook up action buttons

### DIFF
--- a/Assets/Scripts/UnitActionMenu.cs
+++ b/Assets/Scripts/UnitActionMenu.cs
@@ -23,6 +23,16 @@ public class UnitActionMenu : MonoBehaviour
         }
         Instance = this;
         menuPanel.SetActive(false);
+
+        // Ensure buttons trigger actions even if not wired in the inspector
+        if (moveButton != null)
+            moveButton.onClick.AddListener(OnMoveButtonPressed);
+        if (attackButton != null)
+            attackButton.onClick.AddListener(OnAttackButtonPressed);
+        if (endTurnButton != null)
+            endTurnButton.onClick.AddListener(OnEndTurnButtonPressed);
+        if (closeButton != null)
+            closeButton.onClick.AddListener(HideMenu);
     }
 
     public void OnMoveButtonPressed()

--- a/Assets/Scripts/UnitInfoPanel.cs
+++ b/Assets/Scripts/UnitInfoPanel.cs
@@ -85,7 +85,8 @@ public class UnitInfoPanel : MonoBehaviour
             }
         }
         statsText.text = stats;
-        descriptionText.text = unit.unitData.description;
+        if (descriptionText != null)
+            descriptionText.text = unit.unitData.description;
     }
 
     public void HidePanel()


### PR DESCRIPTION
## Summary
- avoid null reference in `UnitInfoPanel.ShowInfo`
- register button callbacks in `UnitActionMenu` during Awake

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c877b51d0832c86307fb8c6e581d7