### PR TITLE
Fix action menu input interfering with grid clicks

### DIFF
--- a/Assets/Scripts/GridCursor.cs
+++ b/Assets/Scripts/GridCursor.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 public class GridCursor : MonoBehaviour
 {
@@ -28,6 +29,9 @@ public class GridCursor : MonoBehaviour
 
         if (Input.GetMouseButtonDown(0))
         {
+            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+                return;
+
             if (UnitManager.Instance != null)
             {
                 if (cell != null && UnitManager.Instance.HasSelectedUnit() && UnitManager.Instance.CanMoveToCell(cell))


### PR DESCRIPTION
## Summary
- prevent `GridCursor` clicks when the pointer is over UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9188028c832c9d02ede851bdf22f