### PR TITLE
Fix move highlight disappearing on hover

### DIFF
--- a/Assets/Scripts/GridCursor.cs
+++ b/Assets/Scripts/GridCursor.cs
@@ -15,7 +15,18 @@ public class GridCursor : MonoBehaviour
         {
             if (lastCell != null)
             {
+                bool restoreMove = UnitManager.Instance != null && UnitManager.Instance.IsMoveHighlightedCell(lastCell);
+                bool restoreAttack = UnitManager.Instance != null && UnitManager.Instance.IsAttackHighlightedCell(lastCell);
+                bool restoreAura = UnitManager.Instance != null && UnitManager.Instance.IsAuraHighlightedCell(lastCell);
+
                 lastCell.Unhighlight();
+                if (restoreMove && !restoreAura)
+                    lastCell.Highlight(Color.cyan);
+                if (restoreAttack && !restoreAura && !restoreMove)
+                    lastCell.Highlight(Color.red);
+                if (restoreAura)
+                    lastCell.HighlightAura(new Color(1f, 0.92f, 0.25f, 0.55f));
+
                 StatusBarUI.Instance?.HideCellInfo();
             }
             if (cell != null)

--- a/Assets/Scripts/UnitManager.cs
+++ b/Assets/Scripts/UnitManager.cs
@@ -620,6 +620,16 @@ public class UnitManager : MonoBehaviour
         auraHighlightedCells.Clear();
     }
 
+    public bool IsMoveHighlightedCell(Cell cell)
+    {
+        return highlightedCells.Contains(cell);
+    }
+
+    public bool IsAuraHighlightedCell(Cell cell)
+    {
+        return auraHighlightedCells.Contains(cell);
+    }
+
     // ======== Move preview helpers ========
     public void PreviewPath(Cell cell)
     {


### PR DESCRIPTION
## Summary
- keep track of move and aura highlighted cells in UnitManager
- restore cell highlights after the cursor leaves a tile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c92ef1a34832c8cd711614a7a4229