### PR TITLE
Add Perlin roads & rivers

### DIFF
--- a/Assets/Data/BiomeData/Grassland.asset
+++ b/Assets/Data/BiomeData/Grassland.asset
@@ -20,3 +20,9 @@ MonoBehaviour:
   - terrainType: 5
     tiles:
     - {fileID: 11400000, guid: d54e9211bf6fcb8409f916f957d8672c, type: 2}
+  - terrainType: 2
+    tiles:
+    - {fileID: 11400000, guid: 7677731d9e4685947b6eab1391ef9212, type: 2}
+  - terrainType: 13
+    tiles:
+    - {fileID: 11400000, guid: bdc21fea2f9e8674592458f3d089d439, type: 2}

--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -139,6 +139,17 @@ public class GridManager : MonoBehaviour
             terrainTilemap.SetTile(new Vector3Int(x, y, 0), tile);
     }
 
+    void SetObjectTerrain(int x, int y, TerrainType tType)
+    {
+        Cell cell = cells[x, y];
+        cell.terrainType = tType;
+        cell.moveCost = GetMoveCostForType(tType);
+
+        TileBase tile = GetTileForType(tType);
+        if (tile != null)
+            objectTilemap.SetTile(new Vector3Int(x, y, 0), tile);
+    }
+
     TerrainType ChooseTerrainType(int x, int y)
     {
         float noise = Mathf.PerlinNoise((x + seed) * terrainNoiseScale,
@@ -213,32 +224,32 @@ public class GridManager : MonoBehaviour
     void GenerateRiver(Vector2Int start, Vector2Int end)
     {
         Vector2Int cur = start;
-        SetCellTerrain(cur.x, cur.y, TerrainType.River);
+        SetObjectTerrain(cur.x, cur.y, TerrainType.River);
         while (cur != end)
         {
             if (cur.x < end.x) cur.x++; else if (cur.x > end.x) cur.x--;
             else if (cur.y < end.y) cur.y++; else if (cur.y > end.y) cur.y--;
 
             if (cells[cur.x, cur.y].terrainType == TerrainType.Road)
-                SetCellTerrain(cur.x, cur.y, TerrainType.Bridge);
+                SetObjectTerrain(cur.x, cur.y, TerrainType.Bridge);
             else
-                SetCellTerrain(cur.x, cur.y, TerrainType.River);
+                SetObjectTerrain(cur.x, cur.y, TerrainType.River);
         }
     }
 
     void GenerateRoad(Vector2Int start, Vector2Int end)
     {
         Vector2Int cur = start;
-        SetCellTerrain(cur.x, cur.y, TerrainType.Road);
+        SetObjectTerrain(cur.x, cur.y, TerrainType.Road);
         while (cur != end)
         {
             if (cur.x < end.x) cur.x++; else if (cur.x > end.x) cur.x--;
             else if (cur.y < end.y) cur.y++; else if (cur.y > end.y) cur.y--;
 
             if (cells[cur.x, cur.y].terrainType == TerrainType.River)
-                SetCellTerrain(cur.x, cur.y, TerrainType.Bridge);
+                SetObjectTerrain(cur.x, cur.y, TerrainType.Bridge);
             else
-                SetCellTerrain(cur.x, cur.y, TerrainType.Road);
+                SetObjectTerrain(cur.x, cur.y, TerrainType.Road);
         }
     }
 
@@ -268,6 +279,23 @@ public class GridManager : MonoBehaviour
                 if (usePerlinNoise)
                     type = ChooseTerrainType(x, y);
                 SetCellTerrain(x, y, type);
+            }
+        }
+
+        // Overlay roads and rivers using Perlin noise on the object tilemap
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                if (cells[x, y].terrainType != TerrainType.Grass)
+                    continue;
+
+                float noise = Mathf.PerlinNoise((x + seed + 1000) * objectNoiseScale,
+                                                (y + seed + 1000) * objectNoiseScale);
+                if (noise < 0.15f)
+                    SetObjectTerrain(x, y, TerrainType.River);
+                else if (noise > 0.85f)
+                    SetObjectTerrain(x, y, TerrainType.Road);
             }
         }
 
@@ -464,9 +492,9 @@ public class GridManager : MonoBehaviour
         {
             if (p == entryPoint || p == exitPoint) continue;
             if (cells[p.x, p.y].terrainType == TerrainType.River)
-                SetCellTerrain(p.x, p.y, TerrainType.Bridge);
+                SetObjectTerrain(p.x, p.y, TerrainType.Bridge);
             else
-                SetCellTerrain(p.x, p.y, TerrainType.Road);
+                SetObjectTerrain(p.x, p.y, TerrainType.Road);
         }
     }
 


### PR DESCRIPTION
## Summary
- overlay road and river tiles using the object tilemap
- add SetObjectTerrain helper
- configure perlin noise overlay
- update biome asset with road and river tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531bbf4910832c815b6609b39373c6