### PR TITLE
Add path-based rivers and roads

### DIFF
--- a/Assets/Scripts/DungeonProgressionManager.cs
+++ b/Assets/Scripts/DungeonProgressionManager.cs
@@ -58,6 +58,7 @@ public class DungeonProgressionManager : MonoBehaviour
         }
         var info = levels[level - 1];
         GridManager.Instance.Initialize(info.width, info.height, info.seed, info.biome);
+        GridManager.Instance.GenerateRiverNetwork();
 
         // choose entry/exit positions on opposite sides
         bool horizontal = Random.value > 0.5f;
@@ -78,6 +79,7 @@ public class DungeonProgressionManager : MonoBehaviour
             exit = new Vector2Int(xExit, info.height - 1);
         }
         GridManager.Instance.PlaceEntryExit(entry, exit, level == 1);
+        GridManager.Instance.GenerateRoadPath();
 
         // После размещения входа и выхода генерируем начальные отряды
         UnitManager.Instance?.SpawnInitialUnits();


### PR DESCRIPTION
## Summary
- add river generation system with branching using A*
- expose `GenerateRoadPath` and call it after placing entry/exit
- hook up river and road generation in level creation
- remove old Perlin noise road/river placement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531f29ce44832c9c0f44a7a2f37e7e