### PR TITLE
Fix duplicate menu activation

### DIFF
--- a/Assets/Scripts/UnitActionMenu.cs
+++ b/Assets/Scripts/UnitActionMenu.cs
@@ -56,8 +56,6 @@ public class UnitActionMenu : MonoBehaviour
         Debug.Log($"[DEBUG] ShowMenu вызван для: {(unit != null ? unit.name : "NULL")}");
         currentUnitForMenu = unit;
         menuPanel.SetActive(true);
-
-        menuPanel.SetActive(true);
         Canvas.ForceUpdateCanvases();
 
         bool isPlayer = (unit.faction == FactionManager.PlayerFaction);


### PR DESCRIPTION
## Summary
- remove redundant second activation call in `ShowMenu`

## Testing
- `mcs -target:library -out:/tmp/test.dll @/tmp/csfiles.txt` *(fails: UnityEngine references missing)*

------
https://chatgpt.com/codex/tasks/task_e_685478606e44832ca246faa8a0198500