### PR TITLE
Fix prefabs with invalid BoxCollider2D references

### DIFF
--- a/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandHorseMan.prefab
+++ b/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandHorseMan.prefab
@@ -137,8 +137,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6b9e5f62c48a4c02a7791eba754654a1, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
-  --- !u!61 &8720790648014776940
+  m_EditorClassIdentifier:
+--- !u!61 &8720790648014776940
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandSpearMan.prefab
+++ b/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandSpearMan.prefab
@@ -137,8 +137,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6b9e5f62c48a4c02a7791eba754654a1, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
-  --- !u!61 &8948621684008702816
+  m_EditorClassIdentifier:
+--- !u!61 &8948621684008702816
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}


### PR DESCRIPTION
## Summary
- clean up indentation in Golden Hand prefab YAML files

## Testing
- `grep -n -- '--- !u!61' "Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandHorseMan.prefab"`
- `grep -n -- '--- !u!61' "Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandSpearMan.prefab"`


------
https://chatgpt.com/codex/tasks/task_e_685484f8c8c4832c9dcc39a3f461fe13