### PR TITLE
Remove unused BoxCollider2D components

### DIFF
--- a/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandHorseMan.prefab
+++ b/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandHorseMan.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 7247737578727331079}
   - component: {fileID: 5901132350974582478}
   - component: {fileID: 6175491760507942388}
-  - component: {fileID: 8720790648014776940}
   m_Layer: 0
   m_Name: GoldenHandHorseMan
   m_TagString: Untagged
@@ -137,22 +136,4 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6b9e5f62c48a4c02a7791eba754654a1, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
-  --- !u!61 &8720790648014776940
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8785832555143759317}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Density: 0
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_AutoTiling: 0
-  m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandSpearMan.prefab
+++ b/Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandSpearMan.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 7247737578727331079}
   - component: {fileID: 5901132350974582478}
   - component: {fileID: 4943519687375453160}
-  - component: {fileID: 8948621684008702816}
   m_Layer: 0
   m_Name: GoldenHandSpearMan
   m_TagString: Untagged
@@ -137,22 +136,4 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6b9e5f62c48a4c02a7791eba754654a1, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
-  --- !u!61 &8948621684008702816
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8785832555143759317}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Density: 0
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_AutoTiling: 0
-  m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
+  m_EditorClassIdentifier:


### PR DESCRIPTION
## Summary
- remove BoxCollider2D components from Golden Hand HorseMan and SpearMan prefabs

## Testing
- `grep -n 'BoxCollider2D' "Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandHorseMan.prefab"`
- `grep -n 'BoxCollider2D' "Assets/Prefabs/Golden Hand/Unit 1-10/GoldenHandSpearMan.prefab"`


------
https://chatgpt.com/codex/tasks/task_e_685484f8c8c4832c9dcc39a3f461fe13