### PR TITLE
Improve combat health icons

### DIFF
--- a/Assets/Scripts/CombatDisplay.cs
+++ b/Assets/Scripts/CombatDisplay.cs
@@ -88,17 +88,27 @@ public class CombatDisplay : MonoBehaviour
 
         if (unit.isCommander)
         {
-            CreateSprite(commanderSpritePrefab, parent, unit.GetComponent<SpriteRenderer>().sprite);
+            var obj = CreateSprite(commanderSpritePrefab, parent, unit.GetComponent<SpriteRenderer>().sprite);
+            var rt = obj.GetComponent<RectTransform>();
+            rt.anchoredPosition = Vector2.zero;
         }
         else
         {
-            int count = Mathf.Clamp(unit.currentHP, 0, 10);
+            int count = Mathf.Clamp(Mathf.CeilToInt((float)unit.currentHP / unit.MaxHP * 10), 0, 10);
             for (int i = 0; i < count; i++)
-                CreateSprite(soldierSpritePrefab, parent, unit.GetComponent<SpriteRenderer>().sprite);
+            {
+                var obj = CreateSprite(soldierSpritePrefab, parent, unit.GetComponent<SpriteRenderer>().sprite);
+                var rt = obj.GetComponent<RectTransform>();
+                float w = rt.sizeDelta.x;
+                float h = rt.sizeDelta.y;
+                int row = i / 5;
+                int col = i % 5;
+                rt.anchoredPosition = new Vector2(col * w, -row * h);
+            }
         }
     }
 
-    void CreateSprite(GameObject prefab, Transform parent, Sprite sprite)
+    GameObject CreateSprite(GameObject prefab, Transform parent, Sprite sprite)
     {
         GameObject go;
         if (prefab != null)
@@ -113,13 +123,14 @@ public class CombatDisplay : MonoBehaviour
         var img = go.GetComponent<Image>();
         img.sprite = sprite;
         img.SetNativeSize();
+        return go;
     }
 
     void ApplyDamage(Transform group, Unit unit, int dmg)
     {
         int newHP = Mathf.Max(0, unit.currentHP - dmg);
-        int before = Mathf.Clamp(unit.currentHP, 0, 10);
-        int after = Mathf.Clamp(newHP, 0, 10);
+        int before = Mathf.Clamp(Mathf.CeilToInt((float)unit.currentHP / unit.MaxHP * 10), 0, 10);
+        int after = Mathf.Clamp(Mathf.CeilToInt((float)newHP / unit.MaxHP * 10), 0, 10);
         int toHide = before - after;
         for (int i = 0; i < toHide && group.childCount > 0; i++)
         {


### PR DESCRIPTION
## Summary
- adjust sprite creation to return `GameObject`
- arrange sprites in 2x5 grid
- compute displayed icons via HP percentage
- hide icons based on HP ratio after damage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a02efee8832c8aeecb9ed2924503