### PR TITLE
Flip defender group before battle

### DIFF
--- a/Assets/Scripts/CombatDisplay.cs
+++ b/Assets/Scripts/CombatDisplay.cs
@@ -42,6 +42,10 @@ public class CombatDisplay : MonoBehaviour
         PopulateGroup(leftGroup, attacker);
         PopulateGroup(rightGroup, defender);
 
+        // Flip the defender group horizontally before animation starts
+        if (rightGroup != null)
+            rightGroup.localScale = new Vector3(-1, 1, 1);
+
         Vector3 leftStart = leftGroup.localPosition;
         Vector3 rightStart = rightGroup.localPosition;
         Vector3 leftTarget = leftStart + Vector3.right * approachDistance;


### PR DESCRIPTION
## Summary
- flip defender's group by setting `rightGroup` scale to `(-1,1,1)` at the start of `PlayBattle`

## Testing
- `unity-editor -runTests -projectPath .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a21fa8d4832ca848cc1d8ee17ea7